### PR TITLE
Convert raw_tx from HexBytes to str

### DIFF
--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -125,7 +125,7 @@ def construct_sign_and_send_raw_middleware(private_key_or_account):
                 return make_request(method, params)
 
             account = accounts[transaction['from']]
-            raw_tx = account.signTransaction(transaction).rawTransaction
+            raw_tx = account.signTransaction(transaction).rawTransaction.hex()
 
             return make_request(
                 "eth_sendRawTransaction",


### PR DESCRIPTION
### What was wrong?
`raw_tx = account.signTransaction(transaction).rawTransaction` is a HexByte. This will cause issues when encoding the rpc request. 

Notably, 
```
/lib/python3.7/site-packages/web3/_utils/encoding.py in json_encode(self, obj)
    267             return self._friendly_json_encode(obj)
    268         except TypeError as exc:
--> 269             raise TypeError("Could not encode to JSON: {}".format(exc))
    270 
    271 

TypeError: Could not encode to JSON: dict had unencodable value at keys: 
{'params': because (list had unencodable value at index: [0: because (Object of type HexBytes is not JSON serializable)])}
```

### How was it fixed?
Convert raw_tx from HexBytes to str


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
